### PR TITLE
Fix authorization scheme consistency: use Nostr instead of Schnorr

### DIFF
--- a/index.html
+++ b/index.html
@@ -228,7 +228,7 @@
         <li>
           The client includes the base64-encoded event in the
           <code>Authorization</code> header with the scheme
-          <code>Schnorr</code>.
+          <code>Nostr</code>.
         </li>
         <li>
           The server receives the request and validates the event as per the
@@ -246,7 +246,7 @@
       <h2>HTTP Authorization Header</h2>
       <p>
         The client MUST include the signed event in the
-        <code>Authorization</code> header using the <code>Schnorr</code> scheme.
+        <code>Authorization</code> header using the <code>Nostr</code> scheme.
         The event MUST be base64-encoded.
       </p>
 


### PR DESCRIPTION
## Summary
Fix inconsistency in authorization scheme naming throughout the specification.

## Problem
The specification currently has an inconsistency:
- Text refers to `Schnorr` scheme in authentication flow and HTTP header sections
- Examples correctly show `Authorization: Nostr <token>`
- This conflicts with NIP-98 standard which uses `Nostr` as the scheme name

## Changes Made
- **Authentication Flow section**: Changed scheme reference from `Schnorr` to `Nostr`
- **HTTP Authorization Header section**: Updated scheme documentation from `Schnorr` to `Nostr`
- Ensures consistency between text and examples
- Aligns with NIP-98 standard

## Test Plan
- [x] Verify all authorization scheme references use `Nostr` consistently
- [x] Confirm examples and documentation are aligned
- [x] Check compliance with NIP-98 standard

Fixes #4